### PR TITLE
devcontainer - pull amd64 image explicitly

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
     "image": "resimai/core:latest",
+    "initializeCommand": "docker pull --platform linux/amd64 resimai/core:latest",
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
         "source=root-home,target=/root,type=volume"


### PR DESCRIPTION
## Description of change

Just cloned the repo on a macbook and the devcontainer failed with a very unhelpful message.
Found the logs and it was pulling the image automatically - but trying to pull an arm64 one.
Until we have an arm64 image, we need to run the pull command explicitly with platform set.


## Guide to reproduce test results.

On an Arm Mac:
Remove or untag resimai/core:latest locally
Open this repo (without the initializeCommand)
See it fail
Add the command and re-open
Should work

## Checklist:
- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
